### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/amplify/backend/function/filters3keys/filters3keys-cloudformation-template.json
+++ b/amplify/backend/function/filters3keys/filters3keys-cloudformation-template.json
@@ -78,7 +78,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/stepfunctions1124ff6c/stepfunctions1124ff6c-cloudformation-template.json
+++ b/amplify/backend/function/stepfunctions1124ff6c/stepfunctions1124ff6c-cloudformation-template.json
@@ -78,7 +78,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/stepfunctionsb69c7ccf/stepfunctionsb69c7ccf-cloudformation-template.json
+++ b/amplify/backend/function/stepfunctionsb69c7ccf/stepfunctionsb69c7ccf-cloudformation-template.json
@@ -85,7 +85,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/syncS3Buckets/syncS3Buckets-cloudformation-template.json
+++ b/amplify/backend/function/syncS3Buckets/syncS3Buckets-cloudformation-template.json
@@ -85,7 +85,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }


### PR DESCRIPTION
CloudFormation templates in amplify-cdkv2-stepfunctions have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.